### PR TITLE
Fix typo on Success outputfactory extenion (OSK-4)

### DIFF
--- a/src/OSK.Functions.Outputs.Abstractions/OutputFactoryExtensions.cs
+++ b/src/OSK.Functions.Outputs.Abstractions/OutputFactoryExtensions.cs
@@ -12,7 +12,7 @@ namespace OSK.Functions.Outputs.Abstractions
             return factory.Create(OutputStatusCode.Success);
         }
 
-        public static IOutput Success<TValue>(this IOutputFactory factory, TValue value)
+        public static IOutput<TValue> Success<TValue>(this IOutputFactory factory, TValue value)
         {
             return factory.Create(value, OutputStatusCode.Success);
         }


### PR DESCRIPTION
Motivation
----
There is a bad return type for an extension call

Modifications
-----
* Adjusted return type to returned the type IOutput

Result
-----
Correct IOutput is returned, as expected

Fixes #4