### PR TITLE
Adjust Origination Source to better handle numerous libraries (OSK-3)

### DIFF
--- a/src/OSK.Functions.Outputs.Abstractions/OutputFactoryExtensions.cs
+++ b/src/OSK.Functions.Outputs.Abstractions/OutputFactoryExtensions.cs
@@ -17,99 +17,163 @@ namespace OSK.Functions.Outputs.Abstractions
             return factory.Create(value, OutputStatusCode.Success);
         }
 
-        public static IOutput BadRequest(this IOutputFactory factory, int originationSourceId,
-            params Error[] errors)
+        public static IOutput BadRequest(this IOutputFactory factory,
+            IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
-                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, originationSourceId),
+                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, originationSource),
                 errors);
         }
 
-        public static IOutput BadRequest(this IOutputFactory factory, int originationSourceId,
-            DetailCode detailCode, params Error[] errors)
+        public static IOutput BadRequest(this IOutputFactory factory,
+            string error, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
-                new OutputStatusCode(HttpStatusCode.BadRequest, detailCode, originationSourceId),
-                errors);
+                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, originationSource),
+                new Error[] { new Error(error) });
         }
 
-        public static IOutput<TValue> BadRequest<TValue>(this IOutputFactory factory, int originationSourceId,
-            params Error[] errors)
+        public static IOutput BadRequest(this IOutputFactory factory,
+            string error, DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create(
+                new OutputStatusCode(HttpStatusCode.BadRequest, detailCode, originationSource),
+                new Error[] { new Error(error) });
+        }
+
+        public static IOutput<TValue> BadRequest<TValue>(this IOutputFactory factory,
+            string error, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
-                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, originationSourceId),
-                errors);
+                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, originationSource),
+                new Error[] { new Error(error) });
         }
 
-        public static IOutput<TValue> BadRequest<TValue>(this IOutputFactory factory, int originationSourceId,
-            DetailCode detailCode, params Error[] errors)
+        public static IOutput<TValue> BadRequest<TValue>(this IOutputFactory factory,
+            string error, DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
-                new OutputStatusCode(HttpStatusCode.BadRequest, detailCode, originationSourceId),
-                errors);
+                new OutputStatusCode(HttpStatusCode.BadRequest, detailCode, originationSource),
+                new Error[] { new Error(error) });
         }
 
-        public static IOutput NotFound(this IOutputFactory factory, int originationSourceId,
-            params Error[] errors)
+        public static IOutput BadRequest(this IOutputFactory factory, DetailCode detailCode, 
+            IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
-                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSourceId),
+                new OutputStatusCode(HttpStatusCode.BadRequest, detailCode, originationSource),
                 errors);
         }
 
-        public static IOutput NotFound(this IOutputFactory factory, int originationSourceId,
-            DetailCode detailCode, params Error[] errors)
-        {
-            return factory.Create(
-                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSourceId),
-                errors);
-        }
-
-        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory, int originationSourceId,
-            params Error[] errors)
+        public static IOutput<TValue> BadRequest<TValue>(this IOutputFactory factory, 
+            IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
-                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSourceId),
+                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, originationSource),
                 errors);
         }
 
-        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory, int originationSourceId, 
-            DetailCode detailCode, params Error[] errors)
+        public static IOutput<TValue> BadRequest<TValue>(this IOutputFactory factory,
+            DetailCode detailCode, IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
-                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSourceId),
+                new OutputStatusCode(HttpStatusCode.BadRequest, detailCode, originationSource),
                 errors);
         }
 
-        public static IOutput Exception(this IOutputFactory factory, int originationSourceId,
-            Exception ex)
+        public static IOutput NotFound(this IOutputFactory factory,
+            IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
-                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, originationSourceId),
+                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                errors);
+        }
+
+        public static IOutput NotFound(this IOutputFactory factory,
+            DetailCode detailCode, IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create(
+                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                errors);
+        }
+
+        public static IOutput NotFound(this IOutputFactory factory,
+            string error, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create(
+                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                new Error[] { new Error(error) });
+        }
+
+        public static IOutput NotFound(this IOutputFactory factory,
+            string error, DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create(
+                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                new Error[] { new Error(error) });
+        }
+
+        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory, 
+            IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create<TValue>(
+                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                errors);
+        }
+
+        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory, 
+            DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource, params Error[] errors)
+        {
+            return factory.Create<TValue>(
+                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                errors);
+        }
+
+        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+            string error, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create<TValue>(
+                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                new Error[] { new Error(error) });
+        }
+
+        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+            string error, DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create<TValue>(
+                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                new Error[] { new Error(error) });
+        }
+
+        public static IOutput Exception(this IOutputFactory factory,
+            Exception ex, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create(
+                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, originationSource),
                 ex);
         }
 
-        public static IOutput Exception(this IOutputFactory factory, int originationSourceId,
-            DetailCode detailCode, Exception ex)
+        public static IOutput Exception(this IOutputFactory factory,
+            DetailCode detailCode, Exception ex, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
-                new OutputStatusCode(HttpStatusCode.InternalServerError, detailCode, originationSourceId),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, detailCode, originationSource),
                 ex);
         }
 
-        public static IOutput<TValue> Exception<TValue>(this IOutputFactory factory, int originationSourceId,
-            Exception ex)
+        public static IOutput<TValue> Exception<TValue>(this IOutputFactory factory, Exception ex, 
+            string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
-                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, originationSourceId),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, originationSource),
                 ex);
         }
 
-        public static IOutput<TValue> Exception<TValue>(this IOutputFactory factory, int originationSourceId,
-            DetailCode detailCode, Exception ex)
+        public static IOutput<TValue> Exception<TValue>(this IOutputFactory factory,
+            DetailCode detailCode, Exception ex, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
-                new OutputStatusCode(HttpStatusCode.InternalServerError, detailCode, originationSourceId),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, detailCode, originationSource),
                 ex);
         }
 

--- a/src/OSK.Functions.Outputs.Abstractions/OutputStatusCode.cs
+++ b/src/OSK.Functions.Outputs.Abstractions/OutputStatusCode.cs
@@ -6,27 +6,29 @@ namespace OSK.Functions.Outputs.Abstractions
     {
         #region Static
 
-        public static readonly OutputStatusCode Success = new OutputStatusCode(HttpStatusCode.OK, DetailCode.None, 0);
+        public static readonly OutputStatusCode Success = new OutputStatusCode(HttpStatusCode.OK, DetailCode.None, DefaultSource);
 
         #endregion
 
         #region Variables
 
+        public const string DefaultSource = "None";
+
         public HttpStatusCode StatusCode { get; }
 
         public DetailCode DetailCode { get; }
 
-        public int OriginationSourceId { get; }
+        public string OriginationSource { get; }
 
         #endregion
 
         #region Constructors
 
-        public OutputStatusCode(HttpStatusCode statusCode, DetailCode detailCode, int originationSourceId)
+        public OutputStatusCode(HttpStatusCode statusCode, DetailCode detailCode, string originationSource = DefaultSource)
         {
             StatusCode = statusCode;
             DetailCode = detailCode;
-            OriginationSourceId = originationSourceId;
+            OriginationSource = originationSource;
         }
 
         #endregion
@@ -35,7 +37,7 @@ namespace OSK.Functions.Outputs.Abstractions
 
         public bool IsSuccessCode => StatusCode >= HttpStatusCode.OK && StatusCode < HttpStatusCode.MultipleChoices;
 
-        public override string ToString() => $"{(int)StatusCode}.{DetailCode}.{OriginationSourceId}";
+        public override string ToString() => $"{(int)StatusCode}.{DetailCode}";
 
         #endregion
     }

--- a/src/OSK.Functions.Outputs.UnitTests/Internal/Services/OutputFactoryTests.cs
+++ b/src/OSK.Functions.Outputs.UnitTests/Internal/Services/OutputFactoryTests.cs
@@ -37,7 +37,7 @@ namespace OSK.Functions.Outputs.UnitTests.Internal.Services
         public void Create_OutputStatusCode_VariousCodes_ThrowsExceptionOnExpectedBehavior(HttpStatusCode statusCode, bool shouldPass)
         {
             // Arrange
-            var code = new OutputStatusCode(statusCode, DetailCode.None, 0);
+            var code = new OutputStatusCode(statusCode, DetailCode.None, OutputStatusCode.DefaultSource);
 
             // Act/Assert
             if (shouldPass)
@@ -74,7 +74,7 @@ namespace OSK.Functions.Outputs.UnitTests.Internal.Services
         {
             // Arrange/Act
             var output = _factory.Create(
-                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, 0),
+                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, OutputStatusCode.DefaultSource),
                 new List<Error>()
                 {
                     new Error("Hi")
@@ -104,7 +104,7 @@ namespace OSK.Functions.Outputs.UnitTests.Internal.Services
         {
             // Arrange/Act
             var output = _factory.Create(
-                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, 0),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, OutputStatusCode.DefaultSource),
                 new ArgumentNullException("Hi"));
 
             // Assert
@@ -132,7 +132,7 @@ namespace OSK.Functions.Outputs.UnitTests.Internal.Services
         public void Create_T_OutputStatusCode_VariousCodes_ThrowsExceptionOnExpectedBehavior(HttpStatusCode statusCode, bool shouldPass)
         {
             // Arrange
-            var code = new OutputStatusCode(statusCode, DetailCode.None, 0);
+            var code = new OutputStatusCode(statusCode, DetailCode.None, OutputStatusCode.DefaultSource);
 
             // Act/Assert
             if (shouldPass)
@@ -169,7 +169,7 @@ namespace OSK.Functions.Outputs.UnitTests.Internal.Services
         {
             // Arrange/Act
             var output = _factory.Create<int>(
-                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, 0),
+                new OutputStatusCode(HttpStatusCode.BadRequest, DetailCode.None, OutputStatusCode.DefaultSource),
                 new List<Error>()
                 {
                     new Error("Hi")
@@ -199,7 +199,7 @@ namespace OSK.Functions.Outputs.UnitTests.Internal.Services
         {
             // Arrange/Act
             var output = _factory.Create<int>(
-                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, 0),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, OutputStatusCode.DefaultSource),
                 new ArgumentNullException("Hi"));
 
             // Assert
@@ -215,7 +215,7 @@ namespace OSK.Functions.Outputs.UnitTests.Internal.Services
         {
             // Arrange/Act/Assert
             Assert.Throws<ArgumentNullException>(() => _factory.Create<object>(null!,
-                new OutputStatusCode(HttpStatusCode.OK, DetailCode.None, 0)));
+                new OutputStatusCode(HttpStatusCode.OK, DetailCode.None, OutputStatusCode.DefaultSource)));
         }
 
         #endregion


### PR DESCRIPTION
Motivation
----
The current usage of an int as an origination source id is simply too simplistic to account for numerous consumers of the library and could cause confusion later on

Modifications
-----
* Adjusted the origination source to be a string, which can represent the library being called, rather than a simplistic int and removed the origination from being a part of the status code toString

Result
----
The origination source can better handle differing Services and libraries calling this library

Fixes #3