### PR TITLE
Added mock output project (OSK-7)

### DIFF
--- a/src/OSK.Functions.Outputs.Mocks/MockOutput.cs
+++ b/src/OSK.Functions.Outputs.Mocks/MockOutput.cs
@@ -1,0 +1,24 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OSK.Functions.Outputs.Mocks
+{
+    public class MockOutput : IOutput
+    {
+        public OutputStatusCode Code { get; set; }
+
+        public ErrorInformation? ErrorInformation { get; set; }
+
+        public IOutput<TValue> AsType<TValue>()
+        {
+            return new MockOutput<TValue>()
+            {
+                Code = Code,
+                ErrorInformation = ErrorInformation,
+                Value = default
+            };
+        }
+    }
+}

--- a/src/OSK.Functions.Outputs.Mocks/MockOutputFactory.cs
+++ b/src/OSK.Functions.Outputs.Mocks/MockOutputFactory.cs
@@ -1,0 +1,87 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OSK.Functions.Outputs.Mocks
+{
+    public class MockOutputFactory : IOutputFactory
+    {
+        #region IOutputFactory
+
+        public IOutput Create(OutputStatusCode statusCode)
+        {
+            return CreateMockOutput(statusCode, null, null);
+        }
+
+        public IOutput Create(OutputStatusCode statusCode, IEnumerable<Error> errors)
+        {
+            return CreateMockOutput(statusCode, null, errors);
+        }
+
+        public IOutput Create(OutputStatusCode statusCode, Exception ex)
+        {
+            return CreateMockOutput(statusCode, ex, null);
+        }
+
+        public IOutput<TValue> Create<TValue>(TValue value, OutputStatusCode statusCode)
+        {
+            return CreateMockOutput(value, statusCode, null, null);
+        }
+
+        public IOutput<TValue> Create<TValue>(OutputStatusCode statusCode, IEnumerable<Error> errors)
+        {
+            return CreateMockOutput(statusCode, null, errors).AsType<TValue>();
+        }
+
+        public IOutput<TValue> Create<TValue>(OutputStatusCode statusCode, Exception ex)
+        {
+            return CreateMockOutput(statusCode, ex, null).AsType<TValue>();
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private MockOutput<T> CreateMockOutput<T>(T value, OutputStatusCode statusCode, Exception ex, IEnumerable<Error> errors)
+        {
+            ErrorInformation? errorInformation = null;
+            if (ex != null)
+            {
+                errorInformation = new ErrorInformation(ex);
+            }
+            else if (errors != null && errors.Any())
+            {
+                errorInformation = new ErrorInformation(errors);
+            }
+
+            return new MockOutput<T>()
+            {
+                Code = statusCode,
+                ErrorInformation = errorInformation,
+                Value = value
+            };
+        }
+
+        private MockOutput CreateMockOutput(OutputStatusCode statusCode, Exception ex, IEnumerable<Error> errors)
+        {
+            ErrorInformation? errorInformation = null;
+            if (ex != null)
+            {
+                errorInformation = new ErrorInformation(ex);
+            }
+            else if (errors != null && errors.Any())
+            {
+                errorInformation = new ErrorInformation(errors);
+            }
+
+            return new MockOutput()
+            {
+                Code = statusCode,
+                ErrorInformation = errorInformation
+            };
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.Functions.Outputs.Mocks/MockOutput`1.cs
+++ b/src/OSK.Functions.Outputs.Mocks/MockOutput`1.cs
@@ -1,0 +1,12 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OSK.Functions.Outputs.Mocks
+{
+    public class MockOutput<T> : MockOutput, IOutput<T>
+    {
+        public T Value { get; set; }
+    }
+}

--- a/src/OSK.Functions.Outputs.Mocks/OSK.Functions.Outputs.Mocks.csproj
+++ b/src/OSK.Functions.Outputs.Mocks/OSK.Functions.Outputs.Mocks.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.Functions.Outputs</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<Description>An implementation for OSK.Functions.Outputs meant mainly for unit testing purposes</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, Functions, Outputs, Result, Error, Response, UnitTests</PackageTags>
+		<Authors>BlankDev117</Authors>
+		<Title>OSK.Functions.Outputs.Mocks</Title>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\OSK.Functions.Outputs.Abstractions\OSK.Functions.Outputs.Abstractions.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.Functions.Outputs.sln
+++ b/src/OSK.Functions.Outputs.sln
@@ -11,7 +11,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.Functions.Outputs.Loggi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.Functions.Outputs.UnitTests", "OSK.Functions.Outputs.UnitTests\OSK.Functions.Outputs.UnitTests.csproj", "{FB88CB4C-CEE0-405E-A0BA-78ED50D81A16}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSK.Functions.Outputs.Logging.Abstractions", "OSK.Functions.Outputs.Logging.Abstractions\OSK.Functions.Outputs.Logging.Abstractions.csproj", "{BC5C9531-8393-4C5F-A75C-43B09B4F174B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.Functions.Outputs.Logging.Abstractions", "OSK.Functions.Outputs.Logging.Abstractions\OSK.Functions.Outputs.Logging.Abstractions.csproj", "{BC5C9531-8393-4C5F-A75C-43B09B4F174B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSK.Functions.Outputs.Mocks", "OSK.Functions.Outputs.Mocks\OSK.Functions.Outputs.Mocks.csproj", "{1BE6526B-65E7-4EC0-AE36-C5A70D2CEB62}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{BC5C9531-8393-4C5F-A75C-43B09B4F174B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC5C9531-8393-4C5F-A75C-43B09B4F174B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BC5C9531-8393-4C5F-A75C-43B09B4F174B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BE6526B-65E7-4EC0-AE36-C5A70D2CEB62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BE6526B-65E7-4EC0-AE36-C5A70D2CEB62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BE6526B-65E7-4EC0-AE36-C5A70D2CEB62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BE6526B-65E7-4EC0-AE36-C5A70D2CEB62}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Motivation
----
There is a need to allow unit tests access to a mock output factory since the current ones are internal and provide extra valdiation that may be unnecessary to unit tests

Modifications
----
* Added mock project with limited validation for unit test consumption

Result
----
Unit tests may access a MockOutputFactory

Fixes #7