### PR TITLE
Add typed mock output factory (OSK-9)

### DIFF
--- a/src/OSK.Functions.Outputs.Mocks/MockOutputFactory`1.cs
+++ b/src/OSK.Functions.Outputs.Mocks/MockOutputFactory`1.cs
@@ -1,0 +1,8 @@
+﻿using OSK.Functions.Outputs.Logging.Abstractions;
+
+namespace OSK.Functions.Outputs.Mocks
+{
+    public class MockOutputFactory<TSource>: MockOutputFactory, IOutputFactory<TSource>
+    {
+    }
+}

--- a/src/OSK.Functions.Outputs.Mocks/OSK.Functions.Outputs.Mocks.csproj
+++ b/src/OSK.Functions.Outputs.Mocks/OSK.Functions.Outputs.Mocks.csproj
@@ -16,6 +16,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\OSK.Functions.Outputs.Abstractions\OSK.Functions.Outputs.Abstractions.csproj" />
+		<ProjectReference Include="..\OSK.Functions.Outputs.Logging.Abstractions\OSK.Functions.Outputs.Logging.Abstractions.csproj" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Motivation
----
current mock project does not support a typed output factory

Modifications
----
* Add typed output factory

Result
----
Mock project now provides a typed output factory

Fixes #9