### PR TITLE
Update OutputStatusCode toString (OSK-outputs-13)

### DIFF
--- a/src/OSK.Functions.Outputs.Abstractions/OutputStatusCode.cs
+++ b/src/OSK.Functions.Outputs.Abstractions/OutputStatusCode.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 
 namespace OSK.Functions.Outputs.Abstractions
 {
@@ -20,15 +21,53 @@ namespace OSK.Functions.Outputs.Abstractions
 
         public string OriginationSource { get; }
 
+        private readonly string _codeSuffix; 
+
         #endregion
 
         #region Constructors
 
-        public OutputStatusCode(HttpStatusCode statusCode, DetailCode detailCode, string originationSource = DefaultSource)
+        public OutputStatusCode(HttpStatusCode statusCode, DetailCode detailCode, 
+            string originationSource = DefaultSource)
         {
             StatusCode = statusCode;
             DetailCode = detailCode;
             OriginationSource = originationSource;
+            _codeSuffix = string.IsNullOrWhiteSpace(originationSource) || originationSource == DefaultSource
+                ? string.Empty
+                : $",{originationSource}";
+        }
+
+        public static OutputStatusCode Parse(string statusCode)
+        {
+            var statusCodeParts = statusCode.Split(',');
+            if (statusCodeParts.Length < 1 || statusCodeParts.Length > 2)
+            {
+                throw new InvalidOperationException("The expected status code parts were not found.");
+            }
+
+            var statusParts = statusCodeParts[0].Split(".");
+            if (statusParts.Length != 2)
+            {
+                throw new InvalidOperationException("The expected status parts were not found.");
+            }
+
+            if (!int.TryParse(statusParts[0], out var httpStatusCode) 
+                && !Enum.IsDefined(typeof(HttpStatusCode), httpStatusCode))
+            {
+                throw new InvalidOperationException("The expected http status code was not valid.");
+            }
+            if (!int.TryParse(statusParts[1], out var detailCode) 
+                && !Enum.IsDefined(typeof(DetailCode), detailCode))
+            {
+                throw new InvalidOperationException("The expected detail code was not valid.");
+            }
+
+            var originationSource = statusCodeParts.Length == 1
+                ? DefaultSource
+                : statusCodeParts[1];
+
+            return new OutputStatusCode((HttpStatusCode)httpStatusCode, (DetailCode)detailCode, originationSource);
         }
 
         #endregion
@@ -37,7 +76,11 @@ namespace OSK.Functions.Outputs.Abstractions
 
         public bool IsSuccessCode => StatusCode >= HttpStatusCode.OK && StatusCode < HttpStatusCode.MultipleChoices;
 
-        public override string ToString() => $"{(int)StatusCode}.{DetailCode}";
+        public override string ToString() => $"{(int)StatusCode}.{(int)DetailCode}";
+
+        public string ToString(bool includeOrigination) => includeOrigination
+            ? $"{(int)StatusCode}.{(int)DetailCode},{OriginationSource}"
+            : ToString();
 
         #endregion
     }

--- a/src/OSK.Functions.Outputs.UnitTests/OutputStatusCodeTests.cs
+++ b/src/OSK.Functions.Outputs.UnitTests/OutputStatusCodeTests.cs
@@ -1,0 +1,93 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using System.Net;
+using Xunit;
+
+namespace OSK.Functions.Outputs.UnitTests
+{
+    public class OutputStatusCodeTests
+    {
+        #region ToString
+
+        [Fact]
+        public void ToString_NoOrigination_ConvertsToExpectedStatusString()
+        {
+            // Arrange
+            var outputStatus = new OutputStatusCode(HttpStatusCode.Accepted, DetailCode.DownStreamError);
+
+            // Act
+            var str = outputStatus.ToString();
+
+            // Assert
+            Assert.Equal("202.1", str);
+        }
+
+        [Fact]
+        public void StatusCodeString_IncludesOrigination_ShouldNotIncludeOrigination_ConvertsToExpectedStatusCode()
+        {
+            // Arrange
+            var outputStatus = new OutputStatusCode(HttpStatusCode.OK, DetailCode.None, "Test Library");
+
+            // Act
+            var str = outputStatus.ToString(false);
+
+            // Assert
+            Assert.Equal("200.0", str);
+        }
+
+        [Fact]
+        public void StatusCodeString_IncludesOrigination_ShouldIncludeOrigination_ConvertsToExpectedStatusCode()
+        {
+            // Arrange
+            var outputStatus = new OutputStatusCode(HttpStatusCode.BadGateway, DetailCode.DownStreamError, "Test Library");
+
+            // Act
+            var str = outputStatus.ToString(true);
+
+            // Assert
+            Assert.Equal("502.1,Test Library", str);
+        }
+
+        #endregion
+
+        #region Constructor(string)
+
+        [Theory]
+        [InlineData(HttpStatusCode.OK, DetailCode.None)]
+        public void OutputStatusCode_Constructor_String_StatusStringNoOrigination_ReturnsExpectedOutputStatus(HttpStatusCode statusCode,
+            DetailCode detailCode)
+        {
+            // Arrange
+            var outputStatus = new OutputStatusCode(statusCode, detailCode);
+            var str = outputStatus.ToString();
+
+            // Act
+            var newStatus = OutputStatusCode.Parse(str);
+
+            // Assert
+            Assert.Equal(statusCode, newStatus.StatusCode);
+            Assert.Equal(detailCode, newStatus.DetailCode);
+            // No origination source was included in the ToString, it should be the default
+            Assert.Equal(OutputStatusCode.DefaultSource, newStatus.OriginationSource);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.OK, DetailCode.None)]
+        public void OutputStatusCode_Constructor_String_StatusStringHasOrigination_ReturnsExpectedOutputStatus(HttpStatusCode statusCode,
+            DetailCode detailCode)
+        {
+            // Arrange
+            var outputStatus = new OutputStatusCode(statusCode, detailCode, "Hello World");
+            var str = outputStatus.ToString(true);
+
+            // Act
+            var newStatus = OutputStatusCode.Parse(str);
+
+            // Assert
+            Assert.Equal(statusCode, newStatus.StatusCode);
+            Assert.Equal(detailCode, newStatus.DetailCode);
+            Assert.Equal("Hello World", newStatus.OriginationSource);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Motivation
----
Unless specifically requested, the output for the OutputStatusCode should not include the origination source and it should be the numeric committed

Modifications
----
* Added static helper for parsing OutputStatusCode's from strings
* Added toString override to determine if origination source should be included
* Added UnitTests

Result
----
OutputStatusCode toString will only return the origination source if requested

Fixes #13