### PR TITLE
Adding some extra detail codes and OutputFactoryExtensions (OSK-15)

### DIFF
--- a/src/OSK.Functions.Outputs.Abstractions/DetailCode.cs
+++ b/src/OSK.Functions.Outputs.Abstractions/DetailCode.cs
@@ -3,6 +3,27 @@
     public enum DetailCode
     {
         None = 0,
-        DownStreamError
+
+        /// <summary>
+        /// This is meant to signify an error further down stream that is being propogated back up.
+        /// For example, if service A calls service B, which calls service C, as the response comes back to
+        /// the previous callers, this detail code can be used to help differentiate failures from a call
+        /// in a specific service from another to help determine if circuit breakers or other logic should be
+        /// triggered
+        /// </summary>
+        DownStreamError = 1,
+        NetworkCommunicationError = 2,
+
+        /// <summary>
+        /// The data that an output is associated to has failed due to some part of it being invalid
+        /// </summary>
+        InvalidData = 400,
+
+        /// <summary>
+        /// The data that an outpt is associated to has failed due to some part of it being duplicated
+        /// </summary>
+        DuplicateData = 420,
+
+        Exception = 500
     }
 }

--- a/src/OSK.Functions.Outputs.Abstractions/OutputFactoryExtensions.cs
+++ b/src/OSK.Functions.Outputs.Abstractions/OutputFactoryExtensions.cs
@@ -89,6 +89,74 @@ namespace OSK.Functions.Outputs.Abstractions
 
         #endregion
 
+        #region NotFound
+
+        public static IOutput NotFound(this IOutputFactory factory,
+             IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create(
+                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                errors);
+        }
+
+        public static IOutput NotFound(this IOutputFactory factory,
+            DetailCode detailCode, IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create(
+                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                errors);
+        }
+
+        public static IOutput NotFound(this IOutputFactory factory,
+            string error, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create(
+                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                new Error[] { new Error(error) });
+        }
+
+        public static IOutput NotFound(this IOutputFactory factory,
+            string error, DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create(
+                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                new Error[] { new Error(error) });
+        }
+
+        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+            IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create<TValue>(
+                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                errors);
+        }
+
+        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+            DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource, params Error[] errors)
+        {
+            return factory.Create<TValue>(
+                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                errors);
+        }
+
+        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+            string error, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create<TValue>(
+                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                new Error[] { new Error(error) });
+        }
+
+        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+            string error, DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource)
+        {
+            return factory.Create<TValue>(
+                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                new Error[] { new Error(error) });
+        }
+
+        #endregion
+
         #region Conflict
 
         public static IOutput Conflict(this IOutputFactory factory,
@@ -157,33 +225,33 @@ namespace OSK.Functions.Outputs.Abstractions
 
         #endregion
 
-        #region NotFound
+        #region InternalServerError
 
-        public static IOutput NotFound(this IOutputFactory factory,
+        public static IOutput InternalServerError(this IOutputFactory factory,
              IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
-                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, originationSource),
                 errors);
         }
 
-        public static IOutput NotFound(this IOutputFactory factory,
+        public static IOutput InternalServerError(this IOutputFactory factory,
             DetailCode detailCode, IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
-                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, detailCode, originationSource),
                 errors);
         }
 
-        public static IOutput NotFound(this IOutputFactory factory,
+        public static IOutput InternalServerError(this IOutputFactory factory,
             string error, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
-                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, originationSource),
                 new Error[] { new Error(error) });
         }
 
-        public static IOutput NotFound(this IOutputFactory factory,
+        public static IOutput InternalServerError(this IOutputFactory factory,
             string error, DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
@@ -191,7 +259,7 @@ namespace OSK.Functions.Outputs.Abstractions
                 new Error[] { new Error(error) });
         }
 
-        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+        public static IOutput<TValue> InternalServerError<TValue>(this IOutputFactory factory,
             IEnumerable<Error> errors, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
@@ -199,7 +267,7 @@ namespace OSK.Functions.Outputs.Abstractions
                 errors);
         }
 
-        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+        public static IOutput<TValue> InternalServerError<TValue>(this IOutputFactory factory,
             DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource, params Error[] errors)
         {
             return factory.Create<TValue>(
@@ -207,19 +275,19 @@ namespace OSK.Functions.Outputs.Abstractions
                 errors);
         }
 
-        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+        public static IOutput<TValue> InternalServerError<TValue>(this IOutputFactory factory,
             string error, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
-                new OutputStatusCode(HttpStatusCode.NotFound, DetailCode.None, originationSource),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, originationSource),
                 new Error[] { new Error(error) });
         }
 
-        public static IOutput<TValue> NotFound<TValue>(this IOutputFactory factory,
+        public static IOutput<TValue> InternalServerError<TValue>(this IOutputFactory factory,
             string error, DetailCode detailCode, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
-                new OutputStatusCode(HttpStatusCode.NotFound, detailCode, originationSource),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, detailCode, originationSource),
                 new Error[] { new Error(error) });
         }
 
@@ -304,7 +372,7 @@ namespace OSK.Functions.Outputs.Abstractions
             Exception ex, string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create(
-                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, originationSource),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.Exception, originationSource),
                 ex);
         }
 
@@ -320,7 +388,7 @@ namespace OSK.Functions.Outputs.Abstractions
             string originationSource = OutputStatusCode.DefaultSource)
         {
             return factory.Create<TValue>(
-                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.None, originationSource),
+                new OutputStatusCode(HttpStatusCode.InternalServerError, DetailCode.Exception, originationSource),
                 ex);
         }
 


### PR DESCRIPTION
Motivation
----
The detail codes are mostly meaningless at the moment as we can only use None or DownStreamError

Modifications
----
* Added some extra detail codes to hopefully give this type some extra purpose and meaning
* Added an OutputFactoryExtension method for internal server errors and adjusted the Exception extension to set the exception detail code

Result
----
Some extra detail codes and extension are available

Fixes #15