### PR TITLE
Allow values on error Outputs (OSK-25)

### DIFF
--- a/src/OSK.Functions.Outputs.Abstractions/IOutputResponseBuilder`1.cs
+++ b/src/OSK.Functions.Outputs.Abstractions/IOutputResponseBuilder`1.cs
@@ -12,9 +12,9 @@ namespace OSK.Functions.Outputs.Abstractions
 
         IOutputResponseBuilder<TValue> WithOrigination(string originationSource);
 
-        IOutputResponseBuilder<TValue> AddException(Exception exception);
+        IOutputResponseBuilder<TValue> AddException(Exception exception, TValue value = default);
 
-        IOutputResponseBuilder<TValue> AddError(string error, OutputSpecificityCode specificityCode);
+        IOutputResponseBuilder<TValue> AddError(string error, OutputSpecificityCode specificityCode, TValue value = default);
 
         IOutputResponseBuilder<TValue> AddSuccess(TValue value, OutputSpecificityCode specificityCode = OutputSpecificityCode.Success);
 

--- a/src/OSK.Functions.Outputs/OutputResponseBuilder`1.cs
+++ b/src/OSK.Functions.Outputs/OutputResponseBuilder`1.cs
@@ -37,14 +37,14 @@ namespace OSK.Functions.Outputs
             return this;
         }
 
-        public IOutputResponseBuilder<TValue> AddException(Exception exception)
+        public IOutputResponseBuilder<TValue> AddException(Exception exception, TValue value = default)
         {
             if (exception is null)
             {
                 throw new ArgumentNullException(nameof(exception));
             }
 
-            var output = factory.CreateOutput<TValue>(default, 
+            var output = factory.CreateOutput(value, 
                 new OutputStatusCode(OutputSpecificityCode.UnknownError, _originationSource),
                 new ErrorInformation(exception), 
                 GetDetails());
@@ -54,9 +54,9 @@ namespace OSK.Functions.Outputs
             return this;
         }
 
-        public IOutputResponseBuilder<TValue> AddError(string error, OutputSpecificityCode specificityCode)
+        public IOutputResponseBuilder<TValue> AddError(string error, OutputSpecificityCode specificityCode, TValue value = default)
         {
-            var output = factory.CreateOutput<TValue>(default, 
+            var output = factory.CreateOutput(value, 
                 new OutputStatusCode(specificityCode, _originationSource), 
                 new ErrorInformation(new Error(error)),
                 GetDetails());


### PR DESCRIPTION
Motivation
----
In some cases, values may still want to be returned to the caller despite the output being an error

Modifications
----
* Allow optionally setting a value for an error output

Result
----
Values can now be set on error outputs, if needed

Fixes #25